### PR TITLE
Pagination - Ditched!

### DIFF
--- a/app/controllers/SpecimenTypeController.php
+++ b/app/controllers/SpecimenTypeController.php
@@ -118,8 +118,10 @@ class SpecimenTypeController extends \BaseController {
 			$specimentype->save();
 
 			// redirect
-			return Redirect::route('specimentype.index')
-                ->with('message', trans('messages.success-updating-specimen-type'));
+			$url = Session::get('key');
+			return Redirect::to($url)
+			->with('message', trans('messages.success-updating-specimen-type'));
+		
 		}
 	}
 

--- a/app/views/specimentype/index.blade.php
+++ b/app/views/specimentype/index.blade.php
@@ -1,6 +1,8 @@
+
 @extends("layout")
 @section("content")
 <div>
+
 	<ol class="breadcrumb">
 	  <li><a href="{{{URL::route('user.home')}}}">{{trans('messages.home')}}</a></li>
 	  <li class="active">{{trans('messages.specimen-types')}}</li>
@@ -45,7 +47,9 @@
 					<!-- edit this specimentype (uses the edit method found at GET /specimentype/{id}/edit -->
 						<a class="btn btn-sm btn-info" href="{{ URL::to("specimentype/" . $value->id . "/edit") }}" >
 							<span class="glyphicon glyphicon-edit"></span>
+
 							{{trans('messages.edit')}}
+
 						</a>
 					<!-- delete this specimentype (uses delete method found at GET /specimentype/{id}/delete -->
 						<button class="btn btn-sm btn-danger delete-item-link" 
@@ -58,9 +62,12 @@
 					</td>
 				</tr>
 			@endforeach
+			{{$specimentypes->links()}}
 			</tbody>
 		</table>
-		<?php echo $specimentypes->links(); ?>
+		<?php echo $specimentypes->links();
+		Session::put('key', URL::full()); ?>
+		
 	</div>
 </div>
 @stop


### PR DESCRIPTION
Retaining the current paginated page after
`create/edit/delete/`operations in specimen types. Take note, the change has only been effected on specimen type edit operation, once approved it will be applied to other operations.  Kindly review
@mapesa, @kitsao 
