### PR TITLE
fix for viral load, special characters in select

### DIFF
--- a/app/views/test/edit.blade.php
+++ b/app/views/test/edit.blade.php
@@ -96,7 +96,7 @@
 			                        }
 			                        ?>
 		                            {{ Form::label($fieldName , $measure->name) }}
-		                            {{ Form::select($fieldName, $measure_values, array_search($ans, $measure_values),
+		                            {{ Form::select($fieldName, $measure_values, array_search(htmlspecialchars_decode($ans), $measure_values),
 		                                array('class' => 'form-control result-interpretation-trigger',
 		                                'data-url' => URL::route('test.resultinterpretation'),
 		                                'data-measureid' => $measure->id


### PR DESCRIPTION
In viral load, measures starting with '<' disappear. Should be fixed.
allows < characters to be shown in form select
