### PR TITLE
fix for some tests missing, visit->id NULL in some cases

### DIFF
--- a/app/api/SanitasInterfacer.php
+++ b/app/api/SanitasInterfacer.php
@@ -260,7 +260,8 @@ class SanitasInterfacer implements InterfacerInterface{
         if($labRequest->parentLabNo == '0')
         {
             //Check via the labno, if this is a duplicate request and we already saved the test 
-            $test = Test::where('external_id', '=', $labRequest->labNo)->where('visit_id', '=', $visit->id)->get();
+            $today = date('Y-m-d');
+            $test = Test::where('external_id', '=', $labRequest->labNo)->whereDate('time_created', '=', $today)->get();
             if (!$test->first())
             {
                 //Specimen


### PR DESCRIPTION
in some cases visit->id is null so the query fails to filter properly on just `external_id`, checking on the current date to make sure that the query gets todays test if any.